### PR TITLE
docs: add Codex operating guide and task-management templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Codex Operating Guide (Project Scope)
+
+This file translates the team CLAUDE workflow into Codex-native practices for this repository.
+
+## 1) Plan Mode by Default
+- Use `update_plan` for any non-trivial task (3+ steps, ambiguous requirements, architecture changes, migrations, or production-risky edits).
+- Keep exactly one step `in_progress` and update statuses as work advances.
+- If implementation drifts or fails, stop and re-plan before continuing.
+- Include verification work in the plan, not only build work.
+
+## 2) Scoped Parallelism (Codex equivalent of subagents)
+- Keep context lean: split work into small, explicit plan steps.
+- Offload exploration to tools (`rg`, focused file reads, targeted test commands) instead of loading unnecessary files.
+- Prefer one clear objective per step/command; avoid mixing unrelated concerns.
+- For complex tasks, run independent checks in parallel where practical, then consolidate findings.
+
+## 3) Self-Improvement Loop
+- After user corrections, record reusable lessons in `tasks/lessons.md`.
+- Add prevention rules (what to do next time, trigger conditions, and checklists).
+- At task start, quickly review `tasks/lessons.md` and apply relevant lessons.
+
+## 4) Verification Before Done
+- Never mark work complete without evidence.
+- Run relevant tests/lint/type-checks for touched code.
+- When behavior changes, compare before/after outcomes (logs, API responses, screenshots, or test output).
+- Ask: “Would a staff engineer approve this change for maintainability and risk?”
+
+## 5) Demand Elegance (Balanced)
+- For non-trivial changes, pause and evaluate a simpler/more robust approach before finalizing.
+- Avoid hacky fixes if a clean solution is feasible within scope.
+- For simple bugs, do the minimal correct change; do not over-engineer.
+
+## 6) Autonomous Bug-Fixing
+- When a bug is reported, diagnose and implement a fix end-to-end without asking for step-by-step guidance.
+- Ground fixes in evidence (failing tests, logs, reproducible behavior).
+- Reduce context switching for the user: identify root cause, apply fix, verify.
+
+## 7) Task Management Files
+- Keep an actionable checklist in `tasks/todo.md` for non-trivial tasks.
+- Mark progress as items complete.
+- Add a short “Review / Results” section at the end of each task entry.
+- Capture corrections and durable takeaways in `tasks/lessons.md`.
+
+## 8) Core Engineering Principles
+- Simplicity first: smallest change that fully solves the issue.
+- Root-cause focus: avoid temporary patches.
+- Minimal impact: touch only necessary files and keep blast radius low.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+
+## Agent Workflow (Codex)
+
+- Repository-level Codex operating rules live in `AGENTS.md`.
+- For non-trivial tasks, keep an actionable checklist in `tasks/todo.md`.
+- Capture durable corrections and prevention rules in `tasks/lessons.md`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,15 @@
+# Lessons Learned
+
+Record durable corrections and prevention rules.
+
+## Entry Template
+- **Date:**
+- **Trigger / mistake:**
+- **Correction made:**
+- **Prevention rule:**
+- **How to detect early next time:**
+
+---
+
+## Entries
+- (none yet)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,23 @@
+# Task Plan Template
+
+Use this file for non-trivial tasks. Copy and fill this template per task.
+
+## Task
+- **Name:**
+- **Owner:** Codex
+- **Date:**
+
+## Plan (checkable)
+- [ ] Clarify requirements and constraints
+- [ ] Identify impacted files/components
+- [ ] Implement scoped changes
+- [ ] Verify (tests/lint/typecheck/manual checks)
+- [ ] Summarize results
+
+## Progress Notes
+- 
+
+## Review / Results
+- **What changed:**
+- **Evidence:**
+- **Risks / follow-ups:**


### PR DESCRIPTION
### Motivation
- Translate the CLAUDE-style agent workflow into Codex-native repository guidance so automation and contributors share clear operating rules. 
- Provide a lightweight, repeatable task-management pattern for non-trivial work to keep plans, verification, and lessons discoverable. 
- Encourage evidence-driven changes and verification steps to reduce risk when making edits in the codebase. 

### Description
- Add `AGENTS.md` with Codex-specific operating rules covering plan-first behavior, scoped parallelism, verification-before-done, elegance checks, autonomous bug-fixing, and core engineering principles. 
- Add `tasks/todo.md` as a reusable, checkable task-plan template for non-trivial tasks and `tasks/lessons.md` as a durable lessons/prevention log. 
- Update `README.md` to include an "Agent Workflow (Codex)" section linking to `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`. 
- Commit changes as documentation updates (commit shown as `3ef779f`). 

### Testing
- Ran `git diff --check` to validate whitespace and diff issues and it completed successfully. 
- Verified repository status with `git status --short` and confirmed new files staged/committed. 
- Confirmed last commit with `git log -1 --oneline` which shows the documentation commit `3ef779f`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998097e8ce4832c8fc3ac2d1adc779f)